### PR TITLE
fixes cs_colocation bug for resources with a role

### DIFF
--- a/lib/puppet/provider/cs_colocation/crm.rb
+++ b/lib/puppet/provider/cs_colocation/crm.rb
@@ -54,6 +54,7 @@ Puppet::Type.type(:cs_colocation).provide(:crm, :parent => Puppet::Provider::Crm
         # Notice, we can only interpret colocations of single sets, not multiple sets combined.
         # In Pacemaker speak, this means we can support "A B C" but not e.g. "A B (C D) E".
         # Feel free to contribute a patch for this.
+        primitives = []
         e.each_element('resource_set') do |rset|
           rsetitems = rset.attributes
 
@@ -65,7 +66,6 @@ Puppet::Type.type(:cs_colocation).provide(:crm, :parent => Puppet::Provider::Crm
           end
 
           # Add all referenced resources to the primitives array.
-          primitives = []
           rset.each_element('resource_ref') do |rref|
             rrefitems = rref.attributes
             if rsetrole


### PR DESCRIPTION
When a colocation rule has a primitive with a role (master or slave), that resource is put in a separate resource set. e.g:

```
      <rsc_colocation id="colo_foo_with_bars" score="INFINITY">
        <resource_set id="colo_foo_with_bars-0">
          <resource_ref id="bar_one"/>
          <resource_ref id="bar_two"/>
          <resource_ref id="bar_three"/>
        </resource_set>
        <resource_set id="colo_foo_with_bars-1" role="Master">
          <resource_ref id="ms_foo"/>
        </resource_set>
      </rsc_colocation>
```

The crm provider doesn't currently handle this very well, causing puppet to try to re-insert that colocation rule on every run. 

Emptying the primitives array outside the resource_set loop fixes this bug.

Not sure if pcs provider is also affected...
